### PR TITLE
CP-27: Build fails due to corejs-typeahead webjar

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -56,12 +56,18 @@
       <artifactId>corejs-typeahead</artifactId>
       <version>1.1.1</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.webjars.npm</groupId>
+          <artifactId>jquery</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.webjars.npm/jquery -->
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>jquery</artifactId>
-      <version>3.2.1</version>
+      <version>3.3.1</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
[Fixed]