### PR TITLE
G4RD-42: Revisions to Post-Test Care Pathways form for secondary sites

### DIFF
--- a/care-pathways-data/ui/src/main/resources/PhenoTips/CarePathwaysPostTestSheet.xml
+++ b/care-pathways-data/ui/src/main/resources/PhenoTips/CarePathwaysPostTestSheet.xml
@@ -246,6 +246,16 @@ $xwiki.jsfx.use('uicomponents/widgets/validation/scrollValidation.js')##
               "type" : "1block"
             }
          ]
+      },
+      {
+         'question':'CPQ:35',
+         'formType': 'secondary',
+         'modules':[
+            {
+              "module" : "followUpSecondary",
+              "type" : "1block"
+            }
+         ]
       }
    ]
 )
@@ -414,13 +424,27 @@ These questions should be completed following whole exome testing
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>cascadeTestingRecommended</name>
-      <number>22</number>
+      <number>23</number>
       <prettyName>Was cascade testing for family member(s) recommended?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </cascadeTestingRecommended>
+    <cascadeTestingRecommendedSecondary>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <name>cascadeTestingRecommendedSecondary</name>
+      <number>32</number>
+      <prettyName>Was cascade testing for family member(s) recommended?</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </cascadeTestingRecommendedSecondary>
     <diseases>
       <cache>0</cache>
       <customDisplay>{{velocity}}
@@ -689,7 +713,7 @@ $xwiki.ssx.use('PhenoTips.PatientSheetCode')##
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>noFurtherInvestigations</name>
-      <number>25</number>
+      <number>26</number>
       <prettyName>noFurtherInvestigations</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -703,7 +727,7 @@ $xwiki.ssx.use('PhenoTips.PatientSheetCode')##
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>noFurtherSecondaryInvestigations</name>
-      <number>26</number>
+      <number>27</number>
       <prettyName>noFurtherSecondaryInvestigations</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -717,7 +741,7 @@ $xwiki.ssx.use('PhenoTips.PatientSheetCode')##
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>noInvestigationsAvoided</name>
-      <number>27</number>
+      <number>28</number>
       <prettyName>noInvestigationsAvoided</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -788,7 +812,7 @@ $xwiki.ssx.use('PhenoTips.PatientSheetCode')##
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>prenatalDiagnosisDiscussed</name>
-      <number>23</number>
+      <number>24</number>
       <prettyName>Was prenatal diagnosis using these findings discussed?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -958,7 +982,7 @@ $!value
       <displayType>select</displayType>
       <multiSelect>0</multiSelect>
       <name>sequencingStrategy</name>
-      <number>24</number>
+      <number>25</number>
       <picker>0</picker>
       <prettyName>The WES sequencing strategy for my patient involved:</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -972,6 +996,34 @@ $!value
       <values/>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </sequencingStrategy>
+    <specificSubSpecialistReferralMade>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <name>specificSubSpecialistReferralMade</name>
+      <number>18</number>
+      <prettyName>Was a specific sub-specialist referral made?</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </specificSubSpecialistReferralMade>
+    <specificSubSpecialistReferralMadeSecondary>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <name>specificSubSpecialistReferralMadeSecondary</name>
+      <number>29</number>
+      <prettyName>Was a specific sub-specialist referral made?</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </specificSubSpecialistReferralMadeSecondary>
     <specificSurveillanceRecommended>
       <customDisplay/>
       <defaultValue/>
@@ -979,13 +1031,27 @@ $!value
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>specificSurveillanceRecommended</name>
-      <number>20</number>
+      <number>21</number>
       <prettyName>Was specific surveillance recommended?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </specificSurveillanceRecommended>
+    <specificSurveillanceRecommendedSecondary>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <name>specificSurveillanceRecommendedSecondary</name>
+      <number>31</number>
+      <prettyName>Was specific surveillance recommended?</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </specificSurveillanceRecommendedSecondary>
     <specificSurveillanceStopped>
       <customDisplay/>
       <defaultValue/>
@@ -993,7 +1059,7 @@ $!value
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>specificSurveillanceStopped</name>
-      <number>21</number>
+      <number>22</number>
       <prettyName>Was specific surveillance stopped?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -1007,13 +1073,27 @@ $!value
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>specificTreatmentRecommended</name>
-      <number>18</number>
+      <number>19</number>
       <prettyName>Was specific treatment recommended?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </specificTreatmentRecommended>
+    <specificTreatmentRecommendedSecondary>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <displayType/>
+      <name>specificTreatmentRecommendedSecondary</name>
+      <number>30</number>
+      <prettyName>Was specific treatment recommended?</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </specificTreatmentRecommendedSecondary>
     <specificTreatmentStopped>
       <customDisplay/>
       <defaultValue/>
@@ -1021,7 +1101,7 @@ $!value
       <displayFormType>select</displayFormType>
       <displayType/>
       <name>specificTreatmentStopped</name>
-      <number>19</number>
+      <number>20</number>
       <prettyName>Was specific treatment stopped?</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -1920,12 +2000,24 @@ document.observe('xwiki:dom:updated', attachDuplicateVariantsInPatientSheetValid
       diseasesField.toggle(!noDiagnosisInput.checked);
     });
 
+    var toggleClearableYesNo = function(elem) {
+      // First toggle the element.
+      elem.toggle(!noSecondaryVariantsInput.checked);
+      // If the element is no longer visible, clear all the drop-downs.
+      !elem.visible() &amp;&amp; elem.select("dd select").each(function(selectElem) {
+        var blankOption = selectElem.down("option[value]");
+        blankOption &amp;&amp; (blankOption.selected = true);
+      });
+    };
+
     var noSecondaryVariantsInput = $('PhenoTips.CarePathwaysPostTestSheet_0_noSecondaryVariants');
     $('modules-for-CPQ:23').toggle(!noSecondaryVariantsInput.checked);
     $('modules-for-CPQ:24').toggle(!noSecondaryVariantsInput.checked);
+    $('modules-for-CPQ:35').toggle(!noSecondaryVariantsInput.checked);
     noSecondaryVariantsInput &amp;&amp; noSecondaryVariantsInput.observe('click', function() {
       $('modules-for-CPQ:23').toggle(!noSecondaryVariantsInput.checked);
       $('modules-for-CPQ:24').toggle(!noSecondaryVariantsInput.checked);
+      toggleClearableYesNo($('modules-for-CPQ:35'));
     });
   };
   (XWiki.domIsLoaded &amp;&amp; init()) || document.observe("xwiki:dom:loaded", init);

--- a/vocabularies/src/main/resources/source/CarePathwaysQuestions.tsv
+++ b/vocabularies/src/main/resources/source/CarePathwaysQuestions.tsv
@@ -23,7 +23,7 @@ post test	Based on my patient's sequencing results, I did not need to order the 
 post test	Based on my patient's sequencing result, I recommended the following care plan for my patient:	CPQ:22
 post test	Based on my patient's secondary sequencing results, I ordered the following investigations	CPQ:23
 post test	Based on my patient's secondary sequencing result, I recommended the following care plan for my patient:	CPQ:24
-post test	After WES analysis:	CPQ:25
+post test	Based on my patient's primary sequencing results:	CPQ:25
 post test	Was additional diagnostic testing ordered?	CPQ:26
 post test	Was additional diagnostic testing avoided?	CPQ:27
 post test	Was specific treatment recommended?	CPQ:28
@@ -32,3 +32,9 @@ post test	Was specific surveillance recommended?	CPQ:30
 post test	Was specific surveillance stopped?	CPQ:31
 post test	Was cascade testing for family member(s) recommended?	CPQ:32
 post test	Was prenatal diagnosis using these findings discussed?	CPQ:33
+post test	Was a specific sub-specialist referral made?	CPQ:34
+post test	Based on my patient's secondary sequencing results:	CPQ:35
+post test	Was a specific sub-specialist referral made?	CPQ:36
+post test	Was a specific treatment recommended?	CPQ:37
+post test	Was specific surveillance recommended?	CPQ:38
+post test	Was cascade testing for family member(s) recommended?	CPQ:39

--- a/widgets/src/main/resources/PhenoTips/CarePathways.xml
+++ b/widgets/src/main/resources/PhenoTips/CarePathways.xml
@@ -279,7 +279,13 @@
           #end
         #elseif ($module.module == "followUp")
           &lt;dl&gt;
-            #foreach ($q in ['additionalDiagnosticTestingOrdered', 'additionalDiagnosticTestingAvoided', 'specificTreatmentRecommended', 'specificTreatmentStopped', 'specificSurveillanceRecommended', 'specificSurveillanceStopped', 'cascadeTestingRecommended', 'prenatalDiagnosisDiscussed'])
+            #foreach ($q in ['additionalDiagnosticTestingOrdered', 'additionalDiagnosticTestingAvoided', 'specificSubSpecialistReferralMade', 'specificTreatmentRecommended', 'specificTreatmentStopped', 'specificSurveillanceRecommended', 'specificSurveillanceStopped', 'cascadeTestingRecommended', 'prenatalDiagnosisDiscussed'])
+              #__displayRow($q)
+            #end
+          &lt;/dl&gt;
+        #elseif ($module.module == "followUpSecondary")
+          &lt;dl&gt;
+            #foreach ($q in ['specificSubSpecialistReferralMadeSecondary', 'specificTreatmentRecommendedSecondary', 'specificSurveillanceRecommendedSecondary', 'cascadeTestingRecommendedSecondary'])
               #__displayRow($q)
             #end
           &lt;/dl&gt;
@@ -547,7 +553,13 @@
     &lt;/dl&gt;
   #elseif ($module.module == "followUp")
     &lt;dl&gt;
-      #foreach ($q in ['additionalDiagnosticTestingOrdered', 'additionalDiagnosticTestingAvoided', 'specificTreatmentRecommended', 'specificTreatmentStopped', 'specificSurveillanceRecommended', 'specificSurveillanceStopped', 'cascadeTestingRecommended', 'prenatalDiagnosisDiscussed'])
+      #foreach ($q in ['additionalDiagnosticTestingOrdered', 'additionalDiagnosticTestingAvoided', 'specificSubSpecialistReferralMade', 'specificTreatmentRecommended', 'specificTreatmentStopped', 'specificSurveillanceRecommended', 'specificSurveillanceStopped', 'cascadeTestingRecommended', 'prenatalDiagnosisDiscussed'])
+        #__displayRow($q)
+      #end
+    &lt;/dl&gt;
+  #elseif ($module.module == "followUpSecondary")
+    &lt;dl&gt;
+      #foreach ($q in ['specificSubSpecialistReferralMadeSecondary', 'specificTreatmentRecommendedSecondary', 'specificSurveillanceRecommendedSecondary', 'cascadeTestingRecommendedSecondary'])
         #__displayRow($q)
       #end
     &lt;/dl&gt;


### PR DESCRIPTION
- Amend the question vocabulary

- Add corresponding class properties to the CarePathwaysPostTestSheet

- Add a follow up module for secondary variants in secondary sites

- The new module should not be displayed if "no secondary variants" has been checked